### PR TITLE
Protect against empty message nodes

### DIFF
--- a/lib/postcss-warn-cleaner.js
+++ b/lib/postcss-warn-cleaner.js
@@ -10,6 +10,10 @@ module.exports = postcss.plugin('postcss-warn-cleaner', (opts = {}) => {
     let filePath
 
     let cleaned = result.messages.filter((item) => {
+      if (!item.node) {
+        return false
+      }
+
       filePath = item.node.source.input.file
       return !multimatch(filePath, ignoreFiles).length > 0
     })

--- a/test/index.js
+++ b/test/index.js
@@ -17,7 +17,8 @@ function run (opts) {
 
 test('should not remove warnings', t => {
   return run().then(result => {
-    t.is(result.messages.length, 3)
+    const warnings = result.messages.filter(m => m.type === 'warning')
+    t.is(warnings.length, 3)
   })
 })
 


### PR DESCRIPTION
Sometimes the messages have no nodes. In that case, that message is a fluke!